### PR TITLE
Fix use case with amounts with decimals

### DIFF
--- a/abo/item.php
+++ b/abo/item.php
@@ -108,7 +108,7 @@ class abo_item {
 		if(!$supress_number) {
 			$res .= abo::account($this->dest_account,$this->dest_account_pre)." ";
 		}
-		$res .= sprintf("%s %d %s %s%04d ", abo::account($this->account_number,$this->account_pre), $this->amount, $this->variable_sym, $this->bank, $this->const_sym);
+		$res .= sprintf("%s %.0f %s %s%04d ", abo::account($this->account_number,$this->account_pre), $this->amount, $this->variable_sym, $this->bank, $this->const_sym);
 		
 		$res .= ($this->spec_sym ? $this->spec_sym : ' ').' ';
 		$res .= ($this->message ? mb_substr('AV:'.$this->message, 0,38) : ' ');


### PR DESCRIPTION
While using this class I've managed to get it to create incorrect payments file (refused by FIO). The problem was that header did not match checksums.

Root cause is that sometimes the amounto of single transaction would be off by 1 cent. This fixes it because the amount gets treated as float as it should be (not integer).